### PR TITLE
fixed cooking mastery bonus bug #101

### DIFF
--- a/Extension/sources/injectable/SimPlayer.js
+++ b/Extension/sources/injectable/SimPlayer.js
@@ -630,7 +630,7 @@
 
             getFoodHealingBonus(item) {
                 let bonus = this.modifiers.increasedFoodHealingValue - this.modifiers.decreasedFoodHealingValue;
-                if (item.cookingID !== undefined && this.cookingMastery) {
+                if (this.cookingMastery) {
                     bonus += 20;
                 }
                 if (this.cookingPool) {


### PR DESCRIPTION
Fixed this bug: https://github.com/visua0/Melvor-Idle-Combat-Simulator-Reloaded/issues/101
Removed short-circuit on check for cookingID of the item. While this fix seems to work, please verify that removing this check doesn't cause other issues. cookingID appears to be leftover code that isn't used elsewhere in the project